### PR TITLE
Use settings in update()

### DIFF
--- a/lib/videojs-playlist-ui.js
+++ b/lib/videojs-playlist-ui.js
@@ -21,6 +21,7 @@ const supportsCssPointerEvents = (() => {
 
 const defaults = {
   className: 'vjs-playlist',
+  playOnSelect: false,
   supportsCssPointerEvents
 };
 
@@ -150,7 +151,7 @@ videojs.PlaylistMenu = videojs.Component.extend({
     }
 
     player.on(['loadstart', 'playlistchange'], (event) => {
-      this.update();
+      this.update(settings);
     });
 
     // keep track of whether an ad is playing so that the menu
@@ -198,20 +199,20 @@ videojs.PlaylistMenu = videojs.Component.extend({
     }
   },
   items: [],
-  update() {
+  update(settings) {
     // replace the playlist items being displayed, if necessary
     const playlist = this.player_.playlist();
     if (this.items.length !== playlist.length) {
       // if the menu is currently empty or the state is obviously out
       // of date, rebuild everything.
-      this.createPlaylist_();
+      this.createPlaylist_(settings);
       return;
     }
     for (let i = 0; i < this.items.length; i++) {
       if (this.items[i].item !== playlist[i]) {
         // if any of the playlist items have changed, rebuild the
         // entire playlist
-        this.createPlaylist_();
+        this.createPlaylist_(settings);
         return;
       }
     }

--- a/lib/videojs-playlist-ui.js
+++ b/lib/videojs-playlist-ui.js
@@ -144,14 +144,14 @@ videojs.PlaylistMenu = videojs.Component.extend({
       this.addClass('vjs-csspointerevents');
     }
 
-    this.createPlaylist_(settings);
+    this.createPlaylist_();
 
     if (!videojs.TOUCH_ENABLED) {
       this.addClass('vjs-mouse');
     }
 
     player.on(['loadstart', 'playlistchange'], (event) => {
-      this.update(settings);
+      this.update();
     });
 
     // keep track of whether an ad is playing so that the menu
@@ -163,7 +163,7 @@ videojs.PlaylistMenu = videojs.Component.extend({
       this.removeClass('vjs-ad-playing');
     });
   },
-  createPlaylist_(settings) {
+  createPlaylist_() {
     const playlist = this.player_.playlist() || [];
 
     // remove any existing items
@@ -180,7 +180,7 @@ videojs.PlaylistMenu = videojs.Component.extend({
     for (let i = 0; i < playlist.length; i++) {
       let item = new videojs.PlaylistMenuItem(this.player_, {
         item: playlist[i]
-      }, settings);
+      }, this.options());
       this.items.push(item);
       this.addChild(item);
     }
@@ -199,20 +199,20 @@ videojs.PlaylistMenu = videojs.Component.extend({
     }
   },
   items: [],
-  update(settings) {
+  update() {
     // replace the playlist items being displayed, if necessary
     const playlist = this.player_.playlist();
     if (this.items.length !== playlist.length) {
       // if the menu is currently empty or the state is obviously out
       // of date, rebuild everything.
-      this.createPlaylist_(settings);
+      this.createPlaylist_();
       return;
     }
     for (let i = 0; i < this.items.length; i++) {
       if (this.items[i].item !== playlist[i]) {
         // if any of the playlist items have changed, rebuild the
         // entire playlist
-        this.createPlaylist_(settings);
+        this.createPlaylist_();
         return;
       }
     }


### PR DESCRIPTION
This fixes settings being undefined when `update` is called. I'm still not sure why executing  `player.playlistUi({playOnSelect:true})` is still setting playOnSelect to false.

Update: calling playlistUi() again just adds to the list so I was clicking on the original elements that did not have the playOnSelect option on.