### PR TITLE
Fix querySelector for list creation

### DIFF
--- a/lib/videojs-playlist-ui.js
+++ b/lib/videojs-playlist-ui.js
@@ -239,7 +239,7 @@ class PlaylistMenu extends Component {
 
   createPlaylist_() {
     const playlist = this.player_.playlist() || [];
-    let list = document.querySelector('.vjs-playlist-item-list');
+    let list = this.el_.querySelector('.vjs-playlist-item-list');
     let overlay = this.el_.querySelector('.vjs-playlist-ad-overlay');
 
     if (!list) {


### PR DESCRIPTION
When creating the playlist element, it should just get
`.vjs-playlist-item-list` from the current element and not the whole
document.