### PR TITLE
Fix documentation for placeholder element

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with the class `vjs-playlist` to house the playlist menu:
 <link href="videojs-playlist-ui.vertical.css" rel="stylesheet">
 
 <!-- The playlist menu will be built automatically in here: -->
-<ol class="vjs-playlist"></ol>
+<div class="vjs-playlist"></div>
 
 <!-- Include video.js, the videojs-playlist plugin and this plugin: -->
 <script src="video.js"></script>


### PR DESCRIPTION
Placeholder element should not be an `ol` - the list already creates an
`ol` element.

Placeholder should probably be a `div`.