### PR TITLE
Complete Docs (for 2.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Before this plugin will work at all, it needs an element in the DOM to which to 
 
 ### Default Implementation
 
-By default, the plugin will search for _the first element in the DOM with the `vjs-playlist` class.
+By default, the plugin will search for _the first element in the DOM with the `vjs-playlist` class_.
 
 > [See an example.](example.html)
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 # Video.js Playlist UI
 
-A playlist video picker for video.js
+A playlist video picker for video.js and videojs-playlist
 
 ## Getting Started
 
-Include the plugin script in your page, and a placeholder list element
-with the class `vjs-playlist` to house the playlist menu:
+Include the plugin script in your page, and a placeholder list element with the class `vjs-playlist` to house the playlist menu:
 
 ```html
 <!-- Include the playlist menu styles somewhere in your page: -->
@@ -22,46 +21,70 @@ with the class `vjs-playlist` to house the playlist menu:
 <script src="videojs-playlist-ui.js"></script>
 
 <script>
-  // Now you can initialize the plugin and build the playlist whenever
-  // you're ready!
+  // Initialize the plugin and build the playlist!
   videojs(document.querySelector('video')).playlistUi();
 </script>
 ```
 
-There's also a [working example](example.html) of the plugin you can
-check out if you're having trouble.
+There's also a [working example](example.html) of the plugin you can check out if you're having trouble.
 
 ## Documentation
 
-### Plugin Options
+Before this plugin will work at all, it needs an element in the DOM to which to attach itself. There are three ways to find/provide this element:
 
-You may pass in an options object to the plugin upon initialization.
-The PlaylistMenu is a regular [video.js
-Component](https://github.com/videojs/video.js/blob/master/docs/guides/components.md)
-so you may pass in [any
-option](https://github.com/videojs/video.js/blob/master/docs/guides/options.md#component-options)
-that is accepted by Components. In addition, this object may contain
-this specialized property:
+### Default Implementation
 
-#### className
+By default, the plugin will search for _the first element in the DOM with the `vjs-playlist` class.
+
+> [See an example.](example.html)
+
+### Using a Custom Class
+
+A custom `className` option can be passed to override the class the plugin will search for to find the root element.
+
+```js
+player.playlistUi({className: 'hello-world'});
+```
+
+> [See an example.](example-custom-class.html)
+
+### Using a Custom Element
+
+A custom element can be passed _in lieu of an options object_ to explicitly define a specific root element.
+
+```js
+player.playlistUi({document.getElementById('hello-world'));
+```
+
+> [See an example.](example-custom-element.html)
+
+### Other Options
+
+_Extra options cannot be passed if passing a custom element._
+
+The options passed to the plugin are passed to the internal `PlaylistMenu` [video.js Component][components]; so, you may pass in [any option][components-options] that is accepted by a component.
+
+In addition, the options object may contain the following specialized properties:
+
+#### `className`
 Type: `string`
-Default: "vjs-playlist"
+Default: `"vjs-playlist"`
 
-The name of the class to search for to populate the playlist menu.
+As mentioned [above](#using-a-custom-class), the name of the class to search for to populate the playlist menu.
 
 #### playOnSelect
-Type: `Boolean`
-Default: false
+Type: `boolean`
+Default: `false`
 
-The default behavior is that the play state is expected to stay the same between videos, if playing continue playing and if paused stay paused when playlist menu items are clicked. When this boolean is set to true, clicking on the playlist menu items will always play the video.
+The default behavior is that the play state is expected to stay the same between videos. If the player is playing when switching playlist items, continue playing. If paused, stay paused.
+
+When this boolean is set to `true`, clicking on the playlist menu items will always play the video.
 
 ## Playlists and Advertisements
 
-The Playlist Menu automatically adapts to ad integrations based on
-[videojs-contrib-ads](https://github.com/videojs/videojs-contrib-ads). When
-a linear ad is being played, the menu will darken and stop responding
-to click or touch events. If you'd prefer to allow your viewers to
-change videos during ad playback, you can override this behavior
-through CSS. You will also need to make sure that your ad integration
-is properly cancelled and cleaned up before switching-- consult the
-documentation for your ad library for details on how to do that.
+The `PlaylistMenu` automatically adapts to ad integrations based on [videojs-contrib-ads][contrib-ads]. When a linear ad is being played, the menu will darken and stop responding to click or touch events. If you'd prefer to allow your viewers to change videos during ad playback, you can override this behavior through CSS. You will also need to make sure that your ad integration is properly cancelled and cleaned up before switching -- consult the documentation for your ad library for details on how to do that.
+
+
+[components]: https://github.com/videojs/video.js/blob/master/docs/guides/components.md
+[components-options]: https://github.com/videojs/video.js/blob/master/docs/guides/options.md#component-options
+[contrib-ads]: https://github.com/videojs/videojs-contrib-ads

--- a/example-custom-class.html
+++ b/example-custom-class.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Video.js Playlist UI - Default Implementation</title>
+  <title>Video.js Playlist UI - Using a Custom Class</title>
   <link href="node_modules/video.js/dist/video-js.css" rel="stylesheet">
   <link href="dist/videojs-playlist-ui.vertical.css" rel="stylesheet">
   <style>
@@ -32,7 +32,7 @@
       float: left;
     }
 
-    .vjs-playlist {
+    .my-custom-class {
       float: left;
       width: 300px;
     }
@@ -40,14 +40,20 @@
 </head>
 <body>
   <div class="info">
-    <h1>Video.js Playlist UI - Default Implementation</h1>
+    <h1>Video.js Playlist UI - Using a Custom Class</h1>
     <p>
       You can see the Video.js Playlist UI plugin in action below. Look at the
       source of this page to see how to use it with your videos.
     </p>
     <p>
-      In the default configuration, the plugin looks for the first element that
-      has the class "vjs-playlist" and uses that as a container for the list.
+      When using a custom class, the plugin looks for the first element that
+      matches the given class and uses that as a container for the list.
+    </p>
+    <p>
+      <strong>Using this option means the default styles WILL NOT apply; so,
+      you'll have to define your own.</strong> This may be desirable or not -
+      depending on your implementation. This example has been left un-styled
+      to demonstrate this fact.
     </p>
   </div>
 
@@ -62,7 +68,7 @@
       <source src="http://vjs.zencdn.net/v/oceans.webm" type="video/webm">
     </video>
 
-    <ol class="vjs-playlist">
+    <ol class="my-custom-class">
       <!--
         The contents of this element will be filled based on the
         currently loaded playlist
@@ -124,7 +130,9 @@
     }]);
 
     // Initialize the playlist-ui plugin with no option (i.e. the defaults).
-    player.playlistUi();
+    player.playlistUi({
+      className: 'my-custom-class'
+    });
   </script>
 </body>
 </html>

--- a/example-custom-element.html
+++ b/example-custom-element.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Video.js Playlist UI - Default Implementation</title>
+  <title>Video.js Playlist UI - Using a Custom Element</title>
   <link href="node_modules/video.js/dist/video-js.css" rel="stylesheet">
   <link href="dist/videojs-playlist-ui.vertical.css" rel="stylesheet">
   <style>
@@ -32,7 +32,7 @@
       float: left;
     }
 
-    .vjs-playlist {
+    #my-custom-element {
       float: left;
       width: 300px;
     }
@@ -40,14 +40,21 @@
 </head>
 <body>
   <div class="info">
-    <h1>Video.js Playlist UI - Default Implementation</h1>
+    <h1>Video.js Playlist UI - Using a Custom Element</h1>
     <p>
       You can see the Video.js Playlist UI plugin in action below. Look at the
       source of this page to see how to use it with your videos.
     </p>
     <p>
-      In the default configuration, the plugin looks for the first element that
-      has the class "vjs-playlist" and uses that as a container for the list.
+      When using a custom element, the plugin uses the element that it was
+      given as a container for the list.
+    </p>
+    <p>
+      <strong>Using this option means the default styles MAY NOT apply (it
+      depends on whether the element has the "vjs-playlist" class) so, you
+      might have to define your own.</strong> This may be desirable or not -
+      depending on your implementation. This example has been left un-styled
+      to demonstrate this fact.
     </p>
   </div>
 
@@ -62,7 +69,7 @@
       <source src="http://vjs.zencdn.net/v/oceans.webm" type="video/webm">
     </video>
 
-    <ol class="vjs-playlist">
+    <ol id="my-custom-element">
       <!--
         The contents of this element will be filled based on the
         currently loaded playlist
@@ -123,8 +130,8 @@
       sources: []
     }]);
 
-    // Initialize the playlist-ui plugin with no option (i.e. the defaults).
-    player.playlistUi();
+    // Initialize the playlist-ui plugin with an element.
+    player.playlistUi(document.getElementById('my-custom-element'));
   </script>
 </body>
 </html>


### PR DESCRIPTION
The docs and examples for this plugin were woefully inadequate - this fixes that.

This is rebased on #31 so that needs merging first.