### PR TITLE
Fix collision in css

### DIFF
--- a/lib/videojs-playlist-ui.js
+++ b/lib/videojs-playlist-ui.js
@@ -153,7 +153,7 @@ class PlaylistMenuItem extends Component {
     // Now playing
     let nowPlayingEl = document.createElement('span');
     let nowPlayingText = this.localize('Now Playing');
-    nowPlayingEl.className = 'vjs-playlist-now-playing';
+    nowPlayingEl.className = 'vjs-playlist-now-playing-text';
     nowPlayingEl.appendChild(document.createTextNode(nowPlayingText));
     nowPlayingEl.setAttribute('title', nowPlayingText);
     this.thumbnail.appendChild(nowPlayingEl);

--- a/lib/videojs-playlist-ui.vertical.less
+++ b/lib/videojs-playlist-ui.vertical.less
@@ -136,7 +136,7 @@ during ads and capture click events on IE<11 */
     opacity: .2;
   }
 
-  .vjs-playlist-thumbnail .vjs-playlist-now-playing {
+  .vjs-playlist-thumbnail .vjs-playlist-now-playing-text {
     display: none;
     position: absolute;
     top: 0;
@@ -145,7 +145,7 @@ during ads and capture click events on IE<11 */
     padding-left: 2px;
   }
 
-  .vjs-selected .vjs-playlist-thumbnail .vjs-playlist-now-playing {
+  .vjs-selected .vjs-playlist-thumbnail .vjs-playlist-now-playing-text {
     display: block;
   }
 

--- a/lib/videojs-playlist-ui.vertical.less
+++ b/lib/videojs-playlist-ui.vertical.less
@@ -224,6 +224,17 @@ during ads and capture click events on IE<11 */
   }
 }
 
+// If now playing / up next are shown, make sure there is room.
+// Only affects thumbnails with very wide aspect ratio, which get
+// stretched vertically. We could avoid the stretching by making this a
+// CSS background image and using background-size: cover; but then it'd
+// get clipped, so not sure that's better.
+@media (min-width: 521px) {
+  .vjs-playlist img {
+    min-height: 85px;
+  }
+}
+
 // Don't show duration when there isn't room
 @media (max-width: 750px) {
   .vjs-playlist .vjs-playlist-duration {

--- a/lib/videojs-playlist-ui.vertical.less
+++ b/lib/videojs-playlist-ui.vertical.less
@@ -37,6 +37,7 @@
   img {
     display: block;
     width: 100%;
+    min-height: 54px;
 
     // Needed because sometimes IE10 adds width / height properties
     height: auto;
@@ -206,5 +207,26 @@ during ads and capture click events on IE<11 */
 
   .vjs-playlist .vjs-playlist-name {
     line-height: 22px;
+  }
+}
+
+// Don't show now playing / up next when there isn't room
+@media (max-width: 520px) {
+  // These styles exist both with and without .vjs-mouse
+  .vjs-playlist .vjs-selected .vjs-playlist-thumbnail .vjs-playlist-now-playing-text,
+  .vjs-playlist .vjs-up-next .vjs-up-next-text {
+    display: none;
+  }
+
+  .vjs-mouse.vjs-playlist .vjs-selected .vjs-playlist-thumbnail .vjs-playlist-now-playing-text,
+  .vjs-mouse.vjs-playlist .vjs-up-next .vjs-up-next-text {
+    display: none;
+  }
+}
+
+// Don't show duration when there isn't room
+@media (max-width: 750px) {
+  .vjs-playlist .vjs-playlist-duration {
+    display: none;
   }
 }


### PR DESCRIPTION
We had two different elements named `vjs-playlist-now-playing`, rename one of them to `vjs-playlist-now-playing-text`.