### PR TITLE
fix and simplify removal of vjs-ad-playing class

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -226,17 +226,9 @@ class PlaylistMenu extends Component {
     player.on('adstart', () => {
       this.addClass('vjs-ad-playing');
     });
+
     player.on('adend', () => {
-      if (player.ended()) {
-        // player.ended() is true because the content is done, but the ended event doesn't
-        // trigger until after the postroll is done and the ad implementation has finished
-        // its cycle. We don't consider a postroll ad ended until the "ended" event.
-        player.one('ended', () => {
-          this.removeClass('vjs-ad-playing');
-        });
-      } else {
-        this.removeClass('vjs-ad-playing');
-      }
+      this.removeClass('vjs-ad-playing');
     });
   }
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -7,6 +7,7 @@ import '../src/plugin';
 
 let realIsHtmlSupported;
 let player;
+let oldVideojsBrowser;
 
 const playlist = [{
   name: 'Movie 1',
@@ -38,6 +39,9 @@ QUnit.test('the environment is sane', function(assert) {
 });
 
 function setup() {
+  oldVideojsBrowser = videojs.browser;
+  videojs.browser = videojs.mergeOptions({}, videojs.browser);
+
   const fixture = document.querySelector('#qunit-fixture');
 
   // force HTML support so the tests run in a reasonable
@@ -63,6 +67,7 @@ function setup() {
 }
 
 function teardown() {
+  videojs.browser = oldVideojsBrowser;
   Html5.isSupported = realIsHtmlSupported;
   player.dispose();
   player = null;


### PR DESCRIPTION
This simplifies that adding and removal of the `vjs-ad-playing` class and fixes an issue where that class is sometimes not removed from the playlist sidebar after an ad in iOS, rendering it unusable.

## Problem
Occasionally, `player.ended()` will be `true` when `adend` fires after a preroll, which causes `vjs-ad-playing` to remain on the playlist sidebar until we get an `ended` event (see [here](https://github.com/brightcove/videojs-playlist-ui/blob/master/src/plugin.js#L229-L241)), which doesn't occur until all ads and content have finished.

## Solution
The additional logic inside the `adend` event handler is not necessary. It is sufficient to simply remove the `vjs-ad-playing` class each time there is an `adend` event. Since that additional logic is also what's causing the bug, we can safely remove it.

**Note:** The VJS 6 Travis build was failing due to a read-only `videojs.browser` property being treated as read/write in one of the tests. That is now fixed as well.