### PR TITLE
Allow video names to be equal to empty string

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -183,7 +183,7 @@ class PlaylistMenuItem extends Component {
 
     // Video title
     const titleEl = document.createElement('cite');
-    const titleText = item.name || item.name === "" ? item.name : this.localize('Untitled Video');
+    const titleText = item.name || item.name === '' ? item.name : this.localize('Untitled Video');
 
     titleEl.className = 'vjs-playlist-name';
     titleEl.appendChild(document.createTextNode(titleText));

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -183,7 +183,7 @@ class PlaylistMenuItem extends Component {
 
     // Video title
     const titleEl = document.createElement('cite');
-    const titleText = item.name || item.name === '' ? item.name : this.localize('Untitled Video');
+    const titleText = typeof item.name === 'string' : item.name ? this.localize('Untitled Video');
 
     titleEl.className = 'vjs-playlist-name';
     titleEl.appendChild(document.createTextNode(titleText));

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -183,7 +183,7 @@ class PlaylistMenuItem extends Component {
 
     // Video title
     const titleEl = document.createElement('cite');
-    const titleText = item.name || this.localize('Untitled Video');
+    const titleText = item.name || item.name === "" ? item.name : this.localize('Untitled Video');
 
     titleEl.className = 'vjs-playlist-name';
     titleEl.appendChild(document.createTextNode(titleText));


### PR DESCRIPTION
# Issue
If a video in a playlist is supposed to not show any name, one way to achieve that would be to name the video an empty string (`""`). However, the string is replaced with "Untitled Video" at https://github.com/brightcove/videojs-playlist-ui/blob/master/src/plugin.js#L186 

JavaScript interprets `null`, `undefined`, `0` and `""` as `false`, so perhaps it's just an unintended way to handle that case. I guess it makes more sense to replace the name if it is equal to `undefined` or `null`. In any case, it's a bit weird that the empty string is replaced as if no name was given at all. 

# Change
Allow the video name to be equal to `""` and don't replace it with "Untitled Video".