### PR TITLE
fix: Correct css filename in build:css script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,8 @@
   "scripts": {
     "prebuild": "npm run clean",
     "build": "npm-run-all -p build:*",
-    "build:css": "node-sass src/plugin.scss dist/videojs-playlist-ui.css --output-style=compressed --linefeed=lf",
-    "build:css:postcss": "npm-run-all build:css:main build:css:copy-vertical build:css:copy-no-prefix",
-    "build:css:main": "postcss --verbose -o dist/videojs-playlist-ui.css --config scripts/postcss.config.js src/plugin.css",
+    "build:css": "npm-run-all build:css:sass build:css:copy-vertical build:css:copy-no-prefix",
+    "build:css:sass": "node-sass src/plugin.scss dist/videojs-playlist-ui.css --output-style=compressed --linefeed=lf",
     "build:css:copy-no-prefix": "cp dist/videojs-playlist-ui.css dist/videojs-playlist-ui.vertical.no-prefix.css",
     "build:css:copy-vertical": "cp dist/videojs-playlist-ui.css dist/videojs-playlist-ui.vertical.css",
     "build:js": "rollup -c scripts/rollup.config.js",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "prebuild": "npm run clean",
     "build": "npm-run-all -p build:*",
-    "build:css": "node-sass src/plugin.scss dist/videojs-ssai.css --output-style=compressed --linefeed=lf",
+    "build:css": "node-sass src/plugin.scss dist/videojs-playlist-ui.css --output-style=compressed --linefeed=lf",
     "build:css:postcss": "npm-run-all build:css:main build:css:copy-vertical build:css:copy-no-prefix",
     "build:css:main": "postcss --verbose -o dist/videojs-playlist-ui.css --config scripts/postcss.config.js src/plugin.css",
     "build:css:copy-no-prefix": "cp dist/videojs-playlist-ui.css dist/videojs-playlist-ui.vertical.no-prefix.css",


### PR DESCRIPTION
## Description
`build:css` script is currently outputting `dist/videojs-ssai.css` instead of `dist/videojs-playlist-ui.css`

## Specific Changes proposed
Change css output filename to `videojs-playlist-ui.css`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
