### PR TITLE
Allow custom data attributes on li elements

### DIFF
--- a/example-custom-data.html
+++ b/example-custom-data.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Video.js Playlist UI - Default Implementation</title>
+  <link href="node_modules/video.js/dist/video-js.css" rel="stylesheet">
+  <link href="dist/videojs-playlist-ui.css" rel="stylesheet">
+  <link href="examples.css" rel="stylesheet">
+</head>
+<body>
+  <div class="info">
+    <h1>Video.js Playlist UI - Default Implementation</h1>
+    <p>
+      You can see the Video.js Playlist UI plugin in action below. Look at the
+      source of this page to see how to use it with your videos.
+    </p>
+    <p>
+      In the default configuration, the plugin looks for the first element that
+      has the class "vjs-playlist" and uses that as a container for the list.
+    </p>
+  </div>
+
+  <div class="player-container">
+    <video
+      id="video"
+      class="video-js"
+      height="300"
+      width="600"
+      controls>
+      <source src="http://vjs.zencdn.net/v/oceans.mp4" type="video/mp4">
+      <source src="http://vjs.zencdn.net/v/oceans.webm" type="video/webm">
+    </video>
+
+    <div class="vjs-playlist">
+      <!--
+        The contents of this element will be filled based on the
+        currently loaded playlist
+      -->
+    </div>
+  </div>
+
+  <script src="node_modules/video.js/dist/video.js"></script>
+  <script src="node_modules/videojs-playlist/dist/videojs-playlist.js"></script>
+  <script src="dist/videojs-playlist-ui.js"></script>
+  <script>
+    var player = videojs('video');
+
+    player.playlist([{
+      name: 'Disney\'s Oceans 1',
+      description: 'Explore the depths of our planet\'s oceans. ' +
+        'Experience the stories that connect their world to ours. ' +
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, ' +
+        'sed do eiusmod tempor incididunt ut labore et dolore magna ' +
+        'aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco ' +
+        'laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure ' +
+        'dolor in reprehenderit in voluptate velit esse cillum dolore eu ' +
+        'fugiat nulla pariatur. Excepteur sint occaecat cupidatat non ' +
+        'proident, sunt in culpa qui officia deserunt mollit anim id est ' +
+        'laborum.',
+      duration: 45,
+      data: {
+	id: 1
+      },
+      sources: [
+        { src: 'http://vjs.zencdn.net/v/oceans.mp4', type: 'video/mp4' },
+        { src: 'http://vjs.zencdn.net/v/oceans.webm', type: 'video/webm' },
+      ],
+
+      // you can use <picture> syntax to display responsive images
+      thumbnail: [
+        {
+          srcset: 'test/example/oceans.jpg',
+          type: 'image/jpeg',
+          media: '(min-width: 400px;)'
+        },
+        {
+          src: 'test/example/oceans-low.jpg'
+        }
+      ]
+    },
+    {
+      name: 'Disney\'s Oceans 2',
+      description: 'Explore the depths of our planet\'s oceans. ' +
+        'Experience the stories that connect their world to ours. ' +
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, ' +
+        'sed do eiusmod tempor incididunt ut labore et dolore magna ' +
+        'aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco ' +
+        'laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure ' +
+        'dolor in reprehenderit in voluptate velit esse cillum dolore eu ' +
+        'fugiat nulla pariatur. Excepteur sint occaecat cupidatat non ' +
+        'proident, sunt in culpa qui officia deserunt mollit anim id est ' +
+        'laborum.',
+      duration: 45,
+      data: {
+	id: 2
+      },
+      sources: [
+        { src: 'http://vjs.zencdn.net/v/oceans.mp4?2', type: 'video/mp4' },
+        { src: 'http://vjs.zencdn.net/v/oceans.webm?2', type: 'video/webm' },
+      ],
+
+      // you can use <picture> syntax to display responsive images
+      thumbnail: [
+        {
+          srcset: 'test/example/oceans.jpg',
+          type: 'image/jpeg',
+          media: '(min-width: 400px;)'
+        },
+        {
+          src: 'test/example/oceans-low.jpg'
+        }
+      ]
+    },
+    {
+      name: 'Disney\'s Oceans 3',
+      description: 'Explore the depths of our planet\'s oceans. ' +
+        'Experience the stories that connect their world to ours. ' +
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, ' +
+        'sed do eiusmod tempor incididunt ut labore et dolore magna ' +
+        'aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco ' +
+        'laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure ' +
+        'dolor in reprehenderit in voluptate velit esse cillum dolore eu ' +
+        'fugiat nulla pariatur. Excepteur sint occaecat cupidatat non ' +
+        'proident, sunt in culpa qui officia deserunt mollit anim id est ' +
+        'laborum.',
+      duration: 45,
+      sources: [
+        { src: 'http://vjs.zencdn.net/v/oceans.mp4?3', type: 'video/mp4' },
+        { src: 'http://vjs.zencdn.net/v/oceans.webm?3', type: 'video/webm' },
+      ],
+
+      // you can use <picture> syntax to display responsive images
+      thumbnail: [
+        {
+          srcset: 'test/example/oceans.jpg',
+          type: 'image/jpeg',
+          media: '(min-width: 400px;)'
+        },
+        {
+          src: 'test/example/oceans-low.jpg'
+        }
+      ]
+    }, {
+      name: 'Sintel (No Thumbnail)',
+      description: 'The film follows a girl named Sintel who is searching for a baby dragon she calls Scales.',
+      sources: [
+        { src: 'http://media.w3.org/2010/05/sintel/trailer.mp4', type: 'video/mp4' },
+        { src: 'http://media.w3.org/2010/05/sintel/trailer.webm', type: 'video/webm' },
+        { src: 'http://media.w3.org/2010/05/sintel/trailer.ogv', type: 'video/ogg' }
+      ],
+      thumbnail: false
+    },
+
+    // This is a really underspecified video to demonstrate the
+    // behavior when optional parameters are missing. You'll get better
+    // results with more video metadata!
+    {
+      name: 'Invalid Source',
+      sources: [{
+        src: 'Invalid'
+      }]
+    }]);
+
+    // Initialize the playlist-ui plugin with no option (i.e. the defaults).
+    player.playlistUi();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <li><a href="example-custom-class.html">Example with Custom Class</a></li>
     <li><a href="example-custom-element.html">Example with Custom Element</a></li>
     <li><a href="example-horizontal.html">Example, Horizontal Implementation</a></li>
+    <li><a href="example-custom-data.html">Example with Custom Data Attributes</a></li>
     <li><a href="test/debug.html">Run unit tests in browser.</a></li>
   </ul>
 </body>

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -138,6 +138,17 @@ class PlaylistMenuItem extends Component {
     const li = document.createElement('li');
     const item = this.options_.item;
 
+    if (item.data) {
+      const dataEntries = Object.entries(item.data);
+
+      if(dataEntries.length > 0) {
+	dataEntries.forEach(entry => {
+	  const [key, value] = entry;
+          li.setAttribute(`data-${key}`, value);
+        });
+      }
+    }
+
     li.className = 'vjs-playlist-item';
     li.setAttribute('tabIndex', 0);
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -141,9 +141,10 @@ class PlaylistMenuItem extends Component {
     if (item.data) {
       const dataEntries = Object.entries(item.data);
 
-      if(dataEntries.length > 0) {
-	dataEntries.forEach(entry => {
-	  const [key, value] = entry;
+      if (dataEntries.length > 0) {
+        dataEntries.forEach(entry => {
+          const [key, value] = entry;
+
           li.setAttribute(`data-${key}`, value);
         });
       }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -138,16 +138,14 @@ class PlaylistMenuItem extends Component {
     const li = document.createElement('li');
     const item = this.options_.item;
 
-    if (typeof item.data === 'object' && item.data) {
+    if (typeof item.data === 'object') {
       const dataKeys = Object.keys(item.data);
 
-      if (dataKeys.length > 0) {
-        dataKeys.forEach(key => {
-          const value = item.data[key];
+      dataKeys.forEach(key => {
+        const value = item.data[key];
 
-          li.dataset[key] = value;
-        });
-      }
+        li.dataset[key] = value;
+      });
     }
 
     li.className = 'vjs-playlist-item';

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -220,8 +220,14 @@ QUnit.test('includes custom data attribute if provided', function(assert) {
   assert.strictEqual(items[0].dataset.id,
         playlist[0].data.id,
         'set a single data attribute');
+  assert.strictEqual(items[0].dataset.id,
+        '1',
+        'set a single data attribute (actual value)');
   assert.strictEqual(items[0].dataset.foo,
         playlist[0].data.foo,
+        'set an addtional data attribute');
+  assert.strictEqual(items[0].dataset.foo,
+        'bar',
         'set an addtional data attribute');
 });
 


### PR DESCRIPTION
_Not sure where to appropriately document the functionality. Seems like it might need to be captured on the `videojs-playlist` repo, rather than here?_

## Description
Allow passing of an array of objects as `item.data = [{ key: "value"}];` in order to set `data-` attributes on the `<li>` tag for a given item. 

## Specific Changes proposed
- Look for `item.data` having been passed
- If that attribute is present, iterate over entries
- `li.setAttribute(`data-${key}`, value);`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
