### PR TITLE
feat: Add translations for localizable strings

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -1,0 +1,5 @@
+{
+  "Now Playing": "Aktuelle Wiedergabe",
+  "Up Next": "Als Nächstes",
+  "Untitled Video": "Video ohne Titel"
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,0 +1,5 @@
+{
+  "Now Playing": "Now Playing",
+  "Up Next": "Up Next",
+  "Untitled Video": "Untitled Video"
+}

--- a/lang/es.json
+++ b/lang/es.json
@@ -1,0 +1,5 @@
+{
+  "Now Playing": "Reproduciendo",
+  "Up Next": "A continuación:",
+  "Untitled Video": "Vídeo sin título"
+}

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1,0 +1,5 @@
+{
+  "Now Playing": "En cours de lecture",
+  "Up Next": "À suivre",
+  "Untitled Video": "Vidéo sans titre"
+}

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1,0 +1,5 @@
+{
+  "Now Playing": "現在再生中",
+  "Up Next": "次の動画",
+  "Untitled Video": "無題の動画"
+}

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1,0 +1,5 @@
+{
+  "Now Playing": "지금 재생 중",
+  "Up Next": "다음",
+  "Untitled Video": "제목 없는 비디오"
+}

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -1,0 +1,5 @@
+{
+  "Now Playing": "正在播放",
+  "Up Next": "播放下一个",
+  "Untitled Video": "无标题视频"
+}

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -1,0 +1,5 @@
+{
+  "Now Playing": "正在播放",
+  "Up Next": "播放下一個",
+  "Untitled Video": "未命名視訊"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2507,6 +2507,16 @@
         }
       }
     },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "^7.1.1"
+      }
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -3926,6 +3936,12 @@
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
       }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -11658,6 +11674,41 @@
         "pkg-can-install": "^1.0.3",
         "pkg-ok": "^2.2.0",
         "shelljs": "^0.8.2"
+      }
+    },
+    "videojs-languages": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/videojs-languages/-/videojs-languages-2.0.0.tgz",
+      "integrity": "sha512-YXbGYdzM/2d1ZS+53T1XpzQOVTURE/c33YklIUqHJVoXSYzbuAKZBfjEeRm3qpc7vBpqQbv6XoIiBIEXfOgU7g==",
+      "dev": true,
+      "requires": {
+        "cli": "^1.0.1",
+        "flatten": "1.0.2",
+        "globby": "^8.0.1",
+        "mkdirp": "^0.5.1"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+          "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "slash": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+          "dev": true
+        }
       }
     },
     "videojs-playlist": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:css:copy-vertical": "shx cp dist/videojs-playlist-ui.css dist/videojs-playlist-ui.vertical.css",
     "build:css:sass": "node-sass src/plugin.scss dist/videojs-playlist-ui.css --output-style=compressed --linefeed=lf",
     "build:js": "rollup -c scripts/rollup.config.js",
+    "build:lang": "vjslang --dir dist/lang",
     "clean": "shx rm -rf ./dist ./test/dist",
     "postclean": "shx mkdir -p ./dist ./test/dist",
     "docs": "npm-run-all docs:*",
@@ -63,6 +64,7 @@
     "videojs-generate-postcss-config": "~2.0.1",
     "videojs-generate-rollup-config": "~2.3.1",
     "videojs-generator-verify": "^1.2.0",
+    "videojs-languages": "^2.0.0",
     "videojs-playlist": "^4.2.4",
     "videojs-standard": "~8.0.2"
   },


### PR DESCRIPTION
## Description
This adds string translations for the following languages:

- German (de)
- Spanish (es)
- French (fr)
- Japanese (ja)
- Korean (ko)
- Chinese, Simplified (zh-Hans)
- Chinese, Traditional (zh-Hant)