### PR TITLE
feat: Enabling option to display video descriptions in playlist thumb…

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -199,6 +199,17 @@ class PlaylistMenuItem extends Component {
     titleEl.setAttribute('title', titleText);
     titleContainerEl.appendChild(titleEl);
 
+    // We add thumbnail video description only if specified in playlist options
+    if (item.showDescription) {
+      const descriptionEl = document.createElement('div');
+      const descriptionText = item.description || '';
+
+      descriptionEl.className = 'vjs-playlist-description-visible';
+      descriptionEl.appendChild(document.createTextNode(descriptionText));
+      descriptionEl.setAttribute('title', descriptionText);
+      titleContainerEl.appendChild(descriptionEl);
+    }
+
     return li;
   }
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -206,7 +206,7 @@ class PlaylistMenuItem extends Component {
       const descriptionEl = document.createElement('div');
       const descriptionText = item.description || '';
 
-      descriptionEl.className = 'vjs-playlist-description-visible';
+      descriptionEl.className = 'vjs-playlist-description';
       descriptionEl.appendChild(document.createTextNode(descriptionText));
       descriptionEl.setAttribute('title', descriptionText);
       titleContainerEl.appendChild(descriptionEl);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -107,6 +107,7 @@ class PlaylistMenuItem extends Component {
       throw new Error('Cannot construct a PlaylistMenuItem without an item option');
     }
 
+    playlistItem.showDescription = settings.showDescription;
     super(player, playlistItem);
     this.item = playlistItem.item;
 
@@ -137,6 +138,7 @@ class PlaylistMenuItem extends Component {
   createEl() {
     const li = document.createElement('li');
     const item = this.options_.item;
+    const showDescription = this.options_.showDescription;
 
     if (typeof item.data === 'object') {
       const dataKeys = Object.keys(item.data);
@@ -200,7 +202,7 @@ class PlaylistMenuItem extends Component {
     titleContainerEl.appendChild(titleEl);
 
     // We add thumbnail video description only if specified in playlist options
-    if (item.showDescription) {
+    if (showDescription) {
       const descriptionEl = document.createElement('div');
       const descriptionText = item.description || '';
 

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -90,13 +90,7 @@ $placeholder-background-color: #303030;
     line-height: 20px;
   }
 
-  .vjs-playlist-description {
-    margin: 0;
-    text-overflow: ellipsis;
-    overflow: hidden;
-  }
-
-  .vjs-playlist-description-visible {
+  .vjs-playlist-description{
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
@@ -237,7 +231,7 @@ $placeholder-background-color: #303030;
   font-size: $base-font-size;
 
   .vjs-playlist-description {
-    height: $base-font-size * 3;
+    height: $base-font-size * 2;
     line-height: ceil($base-font-size * 1.5);
   }
 }

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -96,6 +96,15 @@ $placeholder-background-color: #303030;
     overflow: hidden;
   }
 
+  .vjs-playlist-description-visible {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    display: block;
+    font-size: 14px;
+    padding: 0 0 0 2px;
+  }
+
   .vjs-up-next-text {
     display: none;
     padding: .1rem 2px;

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -215,6 +215,32 @@ QUnit.test('includes the video name if provided', function(assert) {
   );
 });
 
+QUnit.test('includes the video description if user specifies it', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi({showDescription: true});
+
+  const items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(
+    items[0].querySelector('.vjs-playlist-description').textContent,
+    playlist[0].description,
+    'description is displayed'
+  );
+});
+
+QUnit.test('hides video description by default', function(assert) {
+  this.player.playlist(playlist);
+  this.player.playlistUi();
+
+  const items = this.fixture.querySelectorAll('.vjs-playlist-item');
+
+  assert.strictEqual(
+    items[0].querySelector('.vjs-playlist-description'),
+    null,
+    'description is not displayed'
+  );
+});
+
 QUnit.test('includes custom data attribute if provided', function(assert) {
   this.player.playlist(playlist);
   this.player.playlistUi();


### PR DESCRIPTION
Adding _showDescription_ flag to allow user to display video descriptions in playlist thumbnails. Descriptions will be hidden by default.
