### PR TITLE
chore: Remove IE-specific code and CSS

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -5,16 +5,6 @@ import {version as VERSION} from '../package.json';
 const dom = videojs.dom || videojs;
 const registerPlugin = videojs.registerPlugin || videojs.plugin;
 
-// Array#indexOf analog for IE8
-const indexOf = function(array, target) {
-  for (let i = 0, length = array.length; i < length; i++) {
-    if (array[i] === target) {
-      return i;
-    }
-  }
-  return -1;
-};
-
 // see https://github.com/Modernizr/Modernizr/blob/master/feature-detects/css/pointerevents.js
 const supportsCssPointerEvents = (() => {
   const element = document.createElement('x');
@@ -129,7 +119,7 @@ class PlaylistMenuItem extends Component {
   }
 
   switchPlaylistItem_(event) {
-    this.player_.playlist.currentItem(indexOf(this.player_.playlist(), this.item));
+    this.player_.playlist.currentItem(this.player_.playlist().indexOf(this.item));
     if (this.playOnSelect) {
       this.player_.play();
     }
@@ -303,9 +293,8 @@ class PlaylistMenu extends Component {
       list.appendChild(item.el_);
     }
 
-    // Inject the ad overlay. IE<11 doesn't support "pointer-events:
-    // none" so we use this element to block clicks during ad
-    // playback.
+    // Inject the ad overlay. We use this element to block clicks during ad
+    // playback and darken the menu to indicate inactivity
     if (!overlay) {
       overlay = document.createElement('li');
       overlay.className = 'vjs-playlist-ad-overlay';

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -19,10 +19,6 @@ $placeholder-background-color: #303030;
 
   img {
     display: block;
-
-    // Needed because sometimes IE10 adds width / height properties
-    height: auto;
-    width: auto;
   }
 
   .vjs-playlist-item-list {
@@ -191,22 +187,10 @@ $placeholder-background-color: #303030;
   }
 }
 
-// Prevent interaction with the playlist menu while ads are playing
-// on browsers that don't support pointer-events (IE<11), prevent scrolling
-// past the ad overlay
-.vjs-playlist.vjs-ad-playing {
-  overflow: hidden;
-}
-
 // prevent clicks and scrolling from affecting the playlist during ads
 .vjs-playlist.vjs-ad-playing.vjs-csspointerevents {
   pointer-events: none;
   overflow: auto;
-
-  // Fix for IE11 pointer-events bug that allowed clicking playlist during ads
-  .vjs-playlist-ad-overlay {
-    pointer-events: auto;
-  }
 }
 
 // darken the playlist menu display to indicate it's not interactive during ads
@@ -217,12 +201,6 @@ $placeholder-background-color: #303030;
   left: 0;
   width: 100%;
   height: 100%;
-
-  // IE8 fallback
-  background-color: #1a1a1a;
-  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
-
-  // modern browsers
   background-color: rgba(0, 0, 0, 0.5);
 }
 


### PR DESCRIPTION
## Description
Since IE support has been dropped, we can remove code and styling that was included purely to support it.
